### PR TITLE
✨ Add pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: .
+    rev: "master"
+    hooks:
+      - id: flutter-import-sorter

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,18 @@
+- &dart
+  id: dart-import-sorter
+  name: Dart Import Sorter
+  entry: pub run import_sorter:main
+  language: system
+  files: \.dart$
+  require_serial: true
+  description: |
+    Dart package to automatically organize your dart imports. Any dart project supported!    
+    Will sort imports alphabetically and then group them in the following order:
+    1. Dart imports
+    2. Flutter imports
+    3. Package imports
+    4. Project imports
+- << : *dart
+  id: flutter-import-sorter
+  name: Flutter Import Sorter
+  entry: flutter pub run import_sorter:main

--- a/README.md
+++ b/README.md
@@ -108,6 +108,28 @@ import_sorter:
 
 If you need another example check the [example app's import_sorter configuration](https://github.com/fluttercommunity/import_sorter/blob/master/example/example_app/pubspec.yaml#L76).
 
+## 🚨 [`pre-commit`](https://pre-commit.com/) Hook
+
+There are two pre-commit hooks available: `dart-import-sorter` and `flutter-import-sorter`. They use `pub run` and `flutter pub run` respectively. Use the former for a generic Dart project and the later for a Flutter project.
+
+Using pre-commit hooks in your project:
+* Install and configure `pre-commit`.
+* Install and configure `import_sorter` using instructions above.
+* Add the following to the `repos` section of your `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/fluttercommunity/import_sorter
+    rev: "master"
+    hooks:
+      - id: dart-import-sorter  # use `flutter-import-sorter` for a Flutter project
+```
+
+* Run initial sort:
+
+```shell
+pre-commit run --all-files
+```
+
 ## 🙋‍♀️🙋‍♂️ Contributing
 
 All contributions are welcome! Just make sure that it's not an already existing issue or pull request.

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -89,7 +89,7 @@ void main(List<String> args) {
     File(filePath).writeAsStringSync(sortedFile[0]);
     importsSorted += sortedFile[1];
     filesFormatted++;
-    final dirChunks = filePath.replaceAll(currentPath, '').split('/');
+    final dirChunks = filePath.replaceAll("$currentPath/", '').split('/');
     stdout.write(
         '${filesFormatted == 1 ? '\n' : ''}┃  ${filesFormatted == dartFiles.keys.length ? '┗' : '┣'}━━✅ Sorted ${sortedFile[1]} imports in ${dirChunks.getRange(0, dirChunks.length - 1).join('/')}/');
     color(


### PR DESCRIPTION
* Added two hooks -- `dart-import-sorter` and `flutter-import-sorter` -- for Dart and Flutter projects respectively.
* Added `pre-config-config.yaml` for the project itself.
* Changed format of paths in the result report to show as relative. This helps to open files in IDE from the report.