### PR TITLE
Convert project imports to relative imports

### DIFF
--- a/bin/main.dart
+++ b/bin/main.dart
@@ -94,9 +94,9 @@ void main(List<String> args) {
     if (file == null) {
       continue;
     }
-
+    final String libFolder = file.path.substring(file.path.indexOf('lib') + 4);
     final sortedFile = sort.sortImports(
-        file.readAsLinesSync(), packageName, emojis, exitOnChange, noComments);
+        file.readAsLinesSync(), packageName, emojis, exitOnChange, noComments,filePath: libFolder);
     if (!sortedFile.updated) {
       continue;
     }

--- a/lib/sort.dart
+++ b/lib/sort.dart
@@ -1,6 +1,32 @@
 // 🎯 Dart imports:
 import 'dart:io';
 
+// Sorts the project imports to relative imports
+// Returns relative import line String
+String convertToRelativeImport(String line,String packageName,String path) {
+  List<String> fileBits = path.split(RegExp(r'[/\\]'));
+  List<String> importBits = line.split('/');
+  importBits.removeAt(0);
+  dynamic doubleDotAmount = 0;
+  int index;
+  for(index=0;index<fileBits.length-1;index++) {
+    if (fileBits[index] == importBits[index]) {
+      continue;
+    }
+    doubleDotAmount = fileBits.length - index -1;
+    break;
+  }
+  List<String> array = List.filled(doubleDotAmount, "..", growable: true);
+  for(int i =0;i < array.length;i++){
+    array.insertAll(array.length, importBits.sublist(index));
+    break;
+  }
+  if(doubleDotAmount == 0 ) {
+    return "import '${importBits.sublist(index).join('/')}";
+  }
+  return " import '${array.join('/')}";
+}
+
 /// Sort the imports
 /// Returns the sorted file as a string at
 /// index 0 and the number of sorted imports
@@ -56,8 +82,15 @@ ImportSortData sortImports(
       } else if (lines[i].contains('package:flutter/')) {
         flutterImports.add(lines[i]);
       } else if (lines[i].contains('package:$package_name/')) {
-        projectImports.add(lines[i]);
+        if(filePath != null) {
+          String import = convertToRelativeImport(lines[i], package_name,filePath);
+          projectImports.add(import);
+        }
+        else {
+         projectImports.add(lines[i]);
+        }
       } else if (lines[i].contains('package:')) {
+
         packageImports.add(lines[i]);
       } else {
         projectRelativeImports.add(lines[i]);

--- a/test/sort_test.dart
+++ b/test/sort_test.dart
@@ -206,6 +206,46 @@ void main(List<String> args) async {
       );
     },
   );
+  test(
+      'Check if convertToRelativeImport returns relative import if importline in file is in same path',
+          () {
+        expect(
+            convertToRelativeImport(
+                'import \'package:test/widgets/dropdown.dart\'',
+                'test',
+                'widgets/label_dropdown.dart'
+            ),
+            'import \'dropdown.dart\''
+        );
+      }
+  );
+  test(
+      'Check if convertToRelativeImport returns relative path if imported file is in parents sibling folder',
+          () {
+        expect(
+            convertToRelativeImport(
+                "import 'package:test/widgets/dropdown.dart';",
+                'test',
+                'screens/screen_one.dart'
+            ),
+            " import '../widgets/dropdown.dart';"
+        );
+      }
+  );
+  test(
+      'Check if convertToRelativeImport returns relative import if imported file in file is in grandparent folder',
+          () {
+        expect(
+            convertToRelativeImport(
+                'import \'package:test/main.dart\';',
+                'test',
+                'widgets/config/config.dart'
+            ),
+            ' import \'../../main.dart\';'
+        );
+      }
+  );
+
 }
 
 void main() {


### PR DESCRIPTION
Closes #59 
- Add conversion of project imports to relative imports for lib files.
- Add test for convertToRelativeImports

Question:
The example app has the following import but no corresponding dependency
`import 'package:flutter_gen/gen_l10n/translations.dart';
`