### PR TITLE
Fix filepath not correctly printed

### DIFF
--- a/bin/import_sorter.dart
+++ b/bin/import_sorter.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 // 📦 Package imports:
 import 'package:args/args.dart';
+import 'package:path/path.dart' show relative;
 import 'package:tint/tint.dart';
 import 'package:yaml/yaml.dart';
 
@@ -46,7 +47,7 @@ void main(List<String> args) {
 
   var emojis = false;
   var noComments = false;
-  final ignoredFiles = [];
+  final ignoredFiles = <String>[];
 
   // Reading from config in pubspec.yaml safely
   if (!argResults.contains('--ignore-config')) {
@@ -79,14 +80,14 @@ void main(List<String> args) {
   }
 
   for (final pattern in ignoredFiles) {
-    dartFiles.removeWhere((key, _) =>
-        RegExp(pattern).hasMatch(key.replaceFirst(currentPath, '')));
+    dartFiles.removeWhere(
+        (key, _) => RegExp(pattern).hasMatch(relative(key, from: currentPath)));
   }
 
   stdout.write('┏━━ Sorting ${dartFiles.length} dart files');
 
   // Sorting and writing to files
-  final sortedFiles = [];
+  final sortedFiles = <String>[];
   final success = '✔'.green();
 
   for (final filePath in dartFiles.keys) {
@@ -111,11 +112,10 @@ void main(List<String> args) {
     stdout.write('\n');
   }
   for (int i = 0; i < sortedFiles.length; i++) {
-    final file = dartFiles[sortedFiles[i]];
+    final file = dartFiles[sortedFiles[i]]!;
     stdout.write(
-        '${sortedFiles.length == 1 ? '\n' : ''}┃  ${i == sortedFiles.length - 1 ? '┗' : '┣'}━━ $success Sorted imports for ${file?.path.replaceFirst(currentPath, '')}/');
-    String filename = file!.path.split(Platform.pathSeparator).last;
-    stdout.write('$filename\n');
+        '${sortedFiles.length == 1 ? '\n' : ''}┃  ${i == sortedFiles.length - 1 ? '┗' : '┣'}━━ '
+        '$success Sorted imports for ${relative(file.path, from: currentPath)}\n');
   }
 
   if (sortedFiles.isEmpty) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   args: ^2.4.2
+  path: ^1.8.0
   tint: ^2.0.1
   yaml: ^3.1.2
 


### PR DESCRIPTION
Problems:
- unexpected leading slash
- duplicated filename

Changes:
- use `path` lib to correctly handle relative path

Before:
```
contains flutter: true
contains registrant: false
┏━━ Sorting 586 dart files
┃  ┗━━ ✔ Sorted imports for /lib/subfolder/page.dart/page.dart
┗━━ ✔ Sorted 1 files in 0.932 seconds
```

After:
```
contains flutter: true
contains registrant: false
┏━━ Sorting 586 dart files
┃  ┗━━ ✔ Sorted imports for lib/subfolder/page.dart
┗━━ ✔ Sorted 1 files in 0.853 seconds
···
